### PR TITLE
CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         restore-keys: setup.py
 
     - name: pylint
-      run: pylint nari
+      run: pylint nari/ext/act
 
   tests:
     name: Tests
@@ -90,5 +90,6 @@ jobs:
           /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
         key: ${{ hashFiles('setup.py') }}
         restore-keys: setup.py
+
     - name: mypy
       run: mypy --namespace-packages --explicit-package-bases nari

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,4 +91,4 @@ jobs:
         key: ${{ hashFiles('setup.py') }}
         restore-keys: setup.py
     - name: mypy
-      run: mypy nari
+      run: mypy --namespace-packages --explicit-package-bases nari

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,8 @@ jobs:
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
-
-    - name: Pip list
-      run: pip list -v
+        pip list -v
 
     - name: pylint
       run: pylint nari/ext/act
@@ -44,11 +41,8 @@ jobs:
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
-
-    - name: Pip list
-      run: pip list -v
+        pip list -v
 
     - name: unittest
       run: python -munittest
@@ -70,11 +64,8 @@ jobs:
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
-
-    - name: Pip list
-      run: pip list -v
+        pip list -v
 
     - name: mypy
       run: mypy --namespace-packages --explicit-package-bases nari

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,94 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install development dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+
+    - name: Pip list
+      run: pip list -v
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
+        key: ${{ hashFiles('setup.py') }}
+        restore-keys: setup.py
+
+    - name: pylint
+      run: pylint nari
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install development dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+
+    - name: Pip list
+      run: pip list -v
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
+        key: ${{ hashFiles('setup.py') }}
+        restore-keys: setup.py
+
+    - name: unittest
+      run: python -munittest
+
+  types:
+    name: Check Types
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install development dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+
+    - name: Pip list
+      run: pip list -v
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
+        key: ${{ hashFiles('setup.py') }}
+        restore-keys: setup.py
+    - name: mypy
+      run: mypy nari

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.py
 
     - name: Install development dependencies
       run: |
@@ -20,14 +23,6 @@ jobs:
 
     - name: Pip list
       run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.py') }}
-        restore-keys: setup.py
 
     - name: pylint
       run: pylint nari/ext/act
@@ -37,12 +32,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.py
 
     - name: Install development dependencies
       run: |
@@ -51,14 +49,6 @@ jobs:
 
     - name: Pip list
       run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.py') }}
-        restore-keys: setup.py
 
     - name: unittest
       run: python -munittest
@@ -68,12 +58,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.py
 
     - name: Install development dependencies
       run: |
@@ -82,14 +75,6 @@ jobs:
 
     - name: Pip list
       run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.py') }}
-        restore-keys: setup.py
 
     - name: mypy
       run: mypy --namespace-packages --explicit-package-bases nari

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2020 Oowazu Nonowazu <oowazu.nonowazu@gmail.com>
+Copyright 2021-2022 xivlogs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
     python_requires='>=3.10',
     packages=find_namespace_packages(include=['nari.ext.*']),
     package_data={'nari.ext.act': ['py.typed']},
+    install_requires=[
+        'nari@git+https://github.com/xivlogs/nari.git@master'
+    ],
     extras_require={
         'dev': dev_requirements,
         'docs': docs_requirements,


### PR DESCRIPTION
Plus a licence while we're at it.

This is a little different to our other CI flows and what I'd like to do in the others. The `setup-python` action now handles caching as well as keeping an up to date `pip` version around. Since we don't really need the listing as a separate stage, I condensed it into the installation output. This should be somewhat faster than our other workflows, and also actually uses the cache (the others have a misconfig).