### PR TITLE
Add vscode config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	"recommendations": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "EditorConfig.EditorConfig"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "files.exclude": {
+    ".mypy_cache": true,
+    "**/*.egg-info": true,
+    "**/Network_*.log": true,
+    "**/Network_*.txt": true,
+    "**/*.pyc": { "when": "$(basename).py" },
+    "**/__pycache__": true,
+    "**/.venv": true
+  },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
     "**/Network_*.txt": true,
     "**/*.pyc": { "when": "$(basename).py" },
     "**/__pycache__": true,
+    "**/env": true,
+    "**/venv": true,
     "**/.venv": true
   },
 }


### PR DESCRIPTION
Settings to avoid cluttering the file tree, and baseline extensions. Effectively cloned from `nari`, at some stage rust stuff will prob need to be added which I documented in Discord for no real reason. Not sure if we'd want to add masks for wheels and whatnot but could be a good idea too.